### PR TITLE
chore: use Always pull policy

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -16,7 +16,7 @@ data:
           tag: latest
       repository: ghcr.io/singularity-data/risingwave
       tag: latest
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
       requests:
         cpu: 100m
         memory: 100Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - --leader-elect
         image: ghcr.io/singularity-data/risingwave-operator:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -5182,7 +5182,7 @@ data:
           tag: latest
       repository: ghcr.io/singularity-data/risingwave
       tag: latest
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
       requests:
         cpu: 100m
         memory: 100Mi
@@ -5291,7 +5291,7 @@ spec:
         command:
         - /manager
         image: ghcr.io/singularity-data/risingwave-operator:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## What's changed and what's your intention?
 use `Always` pull policy for the latest image to ensure the image is latest.



## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
