### PR TITLE
feat: add liveness-probe to meta, compute, frontend and compactor nodes

### DIFF
--- a/pkg/manager/compactor.go
+++ b/pkg/manager/compactor.go
@@ -195,6 +195,16 @@ func generateCompactorDeploy(rw *v1alpha1.RisingWave) *v1.Deployment {
 				},
 			},
 		},
+		// tcp livenes probe
+		LivenessProbe: &corev1.Probe{
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(v1alpha1.CompactorNodePort),
+				},
+			},
+		},
 	}
 
 	if len(spec.CMD) != 0 {

--- a/pkg/manager/compute.go
+++ b/pkg/manager/compute.go
@@ -235,6 +235,16 @@ func generateComputeStatefulSet(rw *v1alpha1.RisingWave) *v1.StatefulSet {
 				ReadOnly:  true,
 			},
 		},
+		// tcp livenes probe
+		LivenessProbe: &corev1.Probe{
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(v1alpha1.ComputeNodePort),
+				},
+			},
+		},
 	}
 
 	if len(spec.CMD) != 0 {

--- a/pkg/manager/frontend.go
+++ b/pkg/manager/frontend.go
@@ -176,6 +176,16 @@ func generateFrontendDeployment(rw *v1alpha1.RisingWave) *v1.Deployment {
 			fmt.Sprintf("http://%s:%d", MetaNodeComponentName(rw.Name), v1alpha1.MetaServerPort),
 		},
 		Ports: spec.Ports,
+		// tcp livenes probe
+		LivenessProbe: &corev1.Probe{
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(v1alpha1.FrontendPort),
+				},
+			},
+		},
 	}
 
 	if len(spec.CMD) != 0 {

--- a/pkg/manager/meta.go
+++ b/pkg/manager/meta.go
@@ -204,6 +204,16 @@ func generateMetaDeployment(rw *v1alpha1.RisingWave) *v1.Deployment {
 			"--prometheus-host",
 			fmt.Sprintf("0.0.0.0:%d", v1alpha1.MetaMetricsPort),
 		},
+		// tcp livenes probe
+		LivenessProbe: &corev1.Probe{
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(v1alpha1.MetaServerPort),
+				},
+			},
+		},
 	}
 
 	var storage []string


### PR DESCRIPTION
## What's changed and what's your intention?

Liveness probe is required to check if the nodes are healthy. If not, they are restarted automatically.

### How does this work?
This PR works by adding an additional "livenessProbe" field to the container struct during the deployment of these nodes.
 
### Limitation
Timeout seconds and other configurations for the probe are hard-coded at the moment. When mature, we should create a configuration file for all the other configurations including items such as Prometheus address and so forth.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#55 