### PR TITLE
feat: add etcd support for meta node deployments

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -136,7 +136,7 @@ const (
 type MetaStorage struct {
 	Type MetaStorageType `json:"type"`
 	// +optional
-	EtcdEndpoint string `json:"etcdEndpoint"`
+	EtcdEndpoint string `json:"etcdEndpoint,omitempty"`
 }
 
 // ComputeNodeSpec defines the spec of compute-node

--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -135,6 +135,8 @@ const (
 // MetaStorage defines spec of meta service.
 type MetaStorage struct {
 	Type MetaStorageType `json:"type"`
+	// +optional
+	EtcdEndpoint string `json:"etcdEndpoint"`
 }
 
 // ComputeNodeSpec defines the spec of compute-node

--- a/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
@@ -3832,6 +3832,8 @@ spec:
                   storage:
                     description: default Memory
                     properties:
+                      etcdEndpoint:
+                        type: string
                       type:
                         description: MetaStorageType defines the storage type of meta
                           node.

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: risingwave-operator-system/risingwave-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: risingwaves.risingwave.singularity-data.com
 spec:
   conversion:
@@ -4956,18 +4956,15 @@ spec:
                     description: ObjectStorageType defines storage provider.
                     type: string
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -3848,6 +3848,8 @@ spec:
                   storage:
                     description: default Memory
                     properties:
+                      etcdEndpoint:
+                        type: string
                       type:
                         description: MetaStorageType defines the storage type of meta
                           node.

--- a/examples/etcd-service.yaml
+++ b/examples/etcd-service.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-0
+  labels:
+    app: etcd-0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd-0
+  template:
+    metadata:
+      labels:
+        app: etcd-0
+    spec:
+      containers:
+      - name: etcd-0
+        image: "quay.io/coreos/etcd:latest"
+        command:
+          - /usr/local/bin/etcd
+          - "--listen-client-urls"
+          - "http://0.0.0.0:2388"
+          - "--advertise-client-urls"
+          - "http://etcd-0:2388"
+          - "--listen-metrics-urls"
+          - "http://0.0.0.0:2379"
+          - "--name"
+          - risedev-meta
+          - "--max-txn-ops"
+          - "999999"
+          - "--auto-compaction-mode"
+          - revision
+          - "--auto-compaction-retention"
+          - "100"
+        ports:
+        - containerPort: 2388
+        - containerPort: 2389
+---
+apiVersion: risingwave.singularity-data.com/v1alpha1
+kind: RisingWave
+metadata:
+  name: test-risingwave-amd64
+  namespace: test
+spec:
+  arch: amd64
+  objectStorage:
+    minIO: {}
+  metaNode:
+    storage:
+      type: ETCD
+      etcdEndpoint: "etcd-0:2388"
+    

--- a/examples/etcd-service.yaml
+++ b/examples/etcd-service.yaml
@@ -36,6 +36,11 @@ spec:
         ports:
         - containerPort: 2388
         - containerPort: 2389
+      volumes:
+      - name: etcd-0-data
+        hostPath:
+          path: /var/lib/etcd
+          type: Directory
 ---
 apiVersion: risingwave.singularity-data.com/v1alpha1
 kind: RisingWave

--- a/go.sum
+++ b/go.sum
@@ -984,6 +984,11 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.24.1 h1:BjCMRDcyEYz03joa3K1+rbshwh1Ay6oB53+iUx2H8UY=
 k8s.io/api v0.24.1/go.mod h1:JhoOvNiLXKTPQ60zh2g0ewpA+bnEYf5q44Flhquh4vQ=
+<<<<<<< HEAD
+=======
+k8s.io/apiextensions-apiserver v0.23.5/go.mod h1:ntcPWNXS8ZPKN+zTXuzYMeg731CP0heCTl6gYBxLcuQ=
+k8s.io/apiextensions-apiserver v0.24.0/go.mod h1:iuVe4aEpe6827lvO6yWQVxiPSpPoSKVjkq+MIdg84cM=
+>>>>>>> feat: add etcd support for meta node
 k8s.io/apiextensions-apiserver v0.24.1 h1:5yBh9+ueTq/kfnHQZa0MAo6uNcPrtxPMpNQgorBaKS0=
 k8s.io/apiextensions-apiserver v0.24.1/go.mod h1:A6MHfaLDGfjOc/We2nM7uewD5Oa/FnEbZ6cD7g2ca4Q=
 k8s.io/apimachinery v0.24.1 h1:ShD4aDxTQKN5zNf8K1RQ2u98ELLdIW7jEnlO9uAMX/I=
@@ -994,6 +999,11 @@ k8s.io/cli-runtime v0.24.1/go.mod h1:14aVvCTqkA7dNXY51N/6hRY3GUjchyWDOwW84qmR3bs
 k8s.io/client-go v0.24.1 h1:w1hNdI9PFrzu3OlovVeTnf4oHDt+FJLd9Ndluvnb42E=
 k8s.io/client-go v0.24.1/go.mod h1:f1kIDqcEYmwXS/vTbbhopMUbhKp2JhOeVTfxgaCIlF8=
 k8s.io/code-generator v0.24.1/go.mod h1:dpVhs00hTuTdTY6jvVxvTFCk6gSMrtfRydbhZwHI15w=
+<<<<<<< HEAD
+=======
+k8s.io/component-base v0.23.5/go.mod h1:c5Nq44KZyt1aLl0IpHX82fhsn84Sb0jjzwjpcA42bY0=
+k8s.io/component-base v0.24.0/go.mod h1:Dgazgon0i7KYUsS8krG8muGiMVtUZxG037l1MKyXgrA=
+>>>>>>> feat: add etcd support for meta node
 k8s.io/component-base v0.24.1 h1:APv6W/YmfOWZfo+XJ1mZwep/f7g7Tpwvdbo9CQLDuts=
 k8s.io/component-base v0.24.1/go.mod h1:DW5vQGYVCog8WYpNob3PMmmsY8A3L9QZNg4j/dV3s38=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/go.sum
+++ b/go.sum
@@ -984,11 +984,6 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.24.1 h1:BjCMRDcyEYz03joa3K1+rbshwh1Ay6oB53+iUx2H8UY=
 k8s.io/api v0.24.1/go.mod h1:JhoOvNiLXKTPQ60zh2g0ewpA+bnEYf5q44Flhquh4vQ=
-<<<<<<< HEAD
-=======
-k8s.io/apiextensions-apiserver v0.23.5/go.mod h1:ntcPWNXS8ZPKN+zTXuzYMeg731CP0heCTl6gYBxLcuQ=
-k8s.io/apiextensions-apiserver v0.24.0/go.mod h1:iuVe4aEpe6827lvO6yWQVxiPSpPoSKVjkq+MIdg84cM=
->>>>>>> feat: add etcd support for meta node
 k8s.io/apiextensions-apiserver v0.24.1 h1:5yBh9+ueTq/kfnHQZa0MAo6uNcPrtxPMpNQgorBaKS0=
 k8s.io/apiextensions-apiserver v0.24.1/go.mod h1:A6MHfaLDGfjOc/We2nM7uewD5Oa/FnEbZ6cD7g2ca4Q=
 k8s.io/apimachinery v0.24.1 h1:ShD4aDxTQKN5zNf8K1RQ2u98ELLdIW7jEnlO9uAMX/I=
@@ -999,11 +994,6 @@ k8s.io/cli-runtime v0.24.1/go.mod h1:14aVvCTqkA7dNXY51N/6hRY3GUjchyWDOwW84qmR3bs
 k8s.io/client-go v0.24.1 h1:w1hNdI9PFrzu3OlovVeTnf4oHDt+FJLd9Ndluvnb42E=
 k8s.io/client-go v0.24.1/go.mod h1:f1kIDqcEYmwXS/vTbbhopMUbhKp2JhOeVTfxgaCIlF8=
 k8s.io/code-generator v0.24.1/go.mod h1:dpVhs00hTuTdTY6jvVxvTFCk6gSMrtfRydbhZwHI15w=
-<<<<<<< HEAD
-=======
-k8s.io/component-base v0.23.5/go.mod h1:c5Nq44KZyt1aLl0IpHX82fhsn84Sb0jjzwjpcA42bY0=
-k8s.io/component-base v0.24.0/go.mod h1:Dgazgon0i7KYUsS8krG8muGiMVtUZxG037l1MKyXgrA=
->>>>>>> feat: add etcd support for meta node
 k8s.io/component-base v0.24.1 h1:APv6W/YmfOWZfo+XJ1mZwep/f7g7Tpwvdbo9CQLDuts=
 k8s.io/component-base v0.24.1/go.mod h1:DW5vQGYVCog8WYpNob3PMmmsY8A3L9QZNg4j/dV3s38=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/controllers/risingwave/factory/risingwave_object_factory.go
+++ b/pkg/controllers/risingwave/factory/risingwave_object_factory.go
@@ -196,6 +196,10 @@ func (f *RisingWaveObjectFactory) patchArgsForMeta(c *corev1.Container) {
 	// TODO support other storages.
 	if metaNodeSpec.Storage.Type == risingwavev1alpha1.InMemory {
 		args = append(args, "--backend", "mem")
+	} else if metaNodeSpec.Storage.Type == risingwavev1alpha1.ETCD {
+		args = append(args, "--backend", "etcd", "--etcd-endpoints", metaNodeSpec.Storage.EtcdEndpoint)
+	} else {
+		panic("unknown storage type")
 	}
 
 	c.Args = args

--- a/pkg/manager/meta.go
+++ b/pkg/manager/meta.go
@@ -231,6 +231,10 @@ func generateMetaDeployment(rw *v1alpha1.RisingWave) *v1.Deployment {
 	var storage []string
 	if spec.Storage.Type == v1alpha1.InMemory {
 		storage = []string{"--backend", "mem"}
+	} else if spec.Storage.Type == v1alpha1.ETCD {
+		storage = []string{"--backend", "etcd", "--etcd-endpoints", spec.Storage.EtcdEndpoint}
+	} else {
+		panic("unknown storage type")
 	}
 
 	// TODO: maybe support other storage


### PR DESCRIPTION
## What's changed and what's your intention?

Add etcd endpoint fields into meta node spec. This results in a new CRD for the risingwave CR. During initialization, the operator can use this new field to deploy the meta node with the necessary arguments to use an ETCD instance for storage.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#51 