### PR TITLE
feat(controller): parallelize the provision of components

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -27,8 +27,9 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=rw,categories=all
-// +kubebuilder:printcolumn:name="Running",type=string,JSONPath=`.status.conditions[?(@.type=="Running")].status`
-// +kubebuilder:printcolumn:name="Storage",type=string,JSONPath=`.status.objectStorage.type`
+// +kubebuilder:printcolumn:name="RUNNING",type=string,JSONPath=`.status.conditions[?(@.type=="Running")].status`
+// +kubebuilder:printcolumn:name="STORAGE",type=string,JSONPath=`.status.objectStorage.type`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // RisingWave is the Schema for the risingwaves API.
 type RisingWave struct {

--- a/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
@@ -21,11 +21,14 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=="Running")].status
-      name: Running
+      name: RUNNING
       type: string
     - jsonPath: .status.objectStorage.type
-      name: Storage
+      name: STORAGE
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/controller/risingwave_controller.go
+++ b/pkg/controller/risingwave_controller.go
@@ -220,11 +220,8 @@ func (c *RisingWaveController) reactiveWorkflow(risingwaveManger *object.RisingW
 				// Sync configs.
 				syncConfigs,
 
-				// Sync component for meta, and wait for the ready barrier.
-				syncMetaComponent, metaComponentReadyBarrier,
-
-				// Sync other components, and wait for the ready barrier.
-				syncOtherComponents, otherComponentsReadyBarrier,
+				// Sync all components, and wait for the ready barrier.
+				syncAllComponents, allComponentsReadyBarrier,
 
 				markConditionRunningAsTrueAndRemoveConditionInitializing,
 			),


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Add a new print column "AGE", commonly printed in other resources, to tell how long a RisingWave object exists.
- Optimize the initialization progress by parallelizing the provision of components since they have a retry mechanism themselves

Before this optimization, it takes about 40 seconds for waiting components to be ready:

```bash
k get rw -w
NAME              RUNNING   STORAGE   AGE
test-risingwave   False     Memory    2s
test-risingwave   False     Memory    20s
test-risingwave   False     Memory    30s
test-risingwave   False     Memory    40s
test-risingwave   True      Memory    40s
test-risingwave   True      Memory    40s
```

And now, it would finish in 30 seconds:

```bash
k get rw -w
NAME              RUNNING   STORAGE   AGE
test-risingwave                       0s
test-risingwave   False     Memory    0s
test-risingwave   False     Memory    0s
test-risingwave   False     Memory    20s
test-risingwave   True      Memory    30s
test-risingwave   True      Memory    30s
```

NOTE: both when the images are already pulled.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

- #66, by parallelizing the provision, the images not present on nodes are also supposed to be pulled simultaneously, leading to a faster initialization. 