### PR TITLE
feat: add validation for etcd endpoint

### DIFF
--- a/apis/risingwave/v1alpha1/validater.go
+++ b/apis/risingwave/v1alpha1/validater.go
@@ -37,6 +37,10 @@ func (r *RisingWave) ValidateCreate() error {
 		if err != nil {
 			return err
 		}
+
+		if r.Spec.MetaNode.Storage.Type == ETCD && r.Spec.MetaNode.Storage.EtcdEndpoint == "" {
+			return NewValidateError("etcd endpoint cannot be empty")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Add webhook validation for storage type of meta node. When ETCD is chosen as the storage type, an etcd endpoint must be defined in the CR.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#85 