### PR TITLE
fix: leave the default group out when global replicas is 0; fix updat…

### DIFF
--- a/examples/risingwave-component-only.yaml
+++ b/examples/risingwave-component-only.yaml
@@ -35,7 +35,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-
     compute:
       groups:
       - name: default

--- a/examples/risingwave-component-only.yaml
+++ b/examples/risingwave-component-only.yaml
@@ -1,0 +1,64 @@
+apiVersion: risingwave.singularity-data.com/v1alpha1
+kind: RisingWave
+metadata:
+  name: risingwave-component-only
+spec:
+  storages:
+    meta:
+      memory: true
+    object:
+      memory: true
+  components:
+    meta:
+      groups:
+      - name: default
+        replicas: 1
+        image: ghcr.io/singularity-data/risingwave:latest
+        # image: public.ecr.aws/x5u3w5h6/risingwave-arm:latest
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+    frontend:
+      groups:
+      - name: default
+        replicas: 1
+        image: ghcr.io/singularity-data/risingwave:latest
+        # image: public.ecr.aws/x5u3w5h6/risingwave-arm:latest
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+
+    compute:
+      groups:
+      - name: default
+        replicas: 1
+        image: ghcr.io/singularity-data/risingwave:latest
+        # image: public.ecr.aws/x5u3w5h6/risingwave-arm:latest
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+    compactor:
+      groups:
+      - name: default
+        replicas: 1
+        image: ghcr.io/singularity-data/risingwave:latest
+        # image: public.ecr.aws/x5u3w5h6/risingwave-arm:latest
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/pkg/webhook/risingwave_validating_webhook_test.go
+++ b/pkg/webhook/risingwave_validating_webhook_test.go
@@ -386,6 +386,88 @@ func Test_RisingWaveValidatingWebhook_ValidateUpdate(t *testing.T) {
 			},
 			pass: false,
 		},
+		"empty-global-image-fail": {
+			patch: func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.Global.Image = ""
+			},
+			pass: false,
+		},
+		"empty-global-image-and-empty-component-images-fail": {
+			patch: func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.Global.Image = ""
+				r.Spec.Global.Replicas = risingwavev1alpha1.RisingWaveGlobalReplicas{}
+				r.Spec.Components.Meta.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+					},
+				}
+				r.Spec.Components.Frontend.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+					},
+				}
+				r.Spec.Components.Compactor.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+					},
+				}
+				r.Spec.Components.Compute.Groups = []risingwavev1alpha1.RisingWaveComputeGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+					},
+				}
+			},
+			pass: false,
+		},
+		"empty-global-image-but-component-images-pass": {
+			patch: func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.Global.Image = ""
+				r.Spec.Global.Replicas = risingwavev1alpha1.RisingWaveGlobalReplicas{}
+				r.Spec.Components.Meta.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+						RisingWaveComponentGroupTemplate: &risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+							Image: "ghcr.io/singularity-data/risingwave:latest",
+						},
+					},
+				}
+				r.Spec.Components.Frontend.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+						RisingWaveComponentGroupTemplate: &risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+							Image: "ghcr.io/singularity-data/risingwave:latest",
+						},
+					},
+				}
+				r.Spec.Components.Compactor.Groups = []risingwavev1alpha1.RisingWaveComponentGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+						RisingWaveComponentGroupTemplate: &risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+							Image: "ghcr.io/singularity-data/risingwave:latest",
+						},
+					},
+				}
+				r.Spec.Components.Compute.Groups = []risingwavev1alpha1.RisingWaveComputeGroup{
+					{
+						Name:     "a",
+						Replicas: 1,
+						RisingWaveComputeGroupTemplate: &risingwavev1alpha1.RisingWaveComputeGroupTemplate{
+							RisingWaveComponentGroupTemplate: risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+								Image: "ghcr.io/singularity-data/risingwave:latest",
+							},
+						},
+					},
+				}
+			},
+			pass: true,
+		},
 	}
 
 	webhook := NewRisingWaveValidatingWebhook()


### PR DESCRIPTION
…ing the replicas groups in status

Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Leave the default groups out when the global replicas are 0
- Improve the webhook about validating images to make sure each group has a valid image
- Fix an issue in updating group replicas in status, and leave the default group out if necessary
- Provide an example to show that the component-only schema works

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
