### PR TITLE
feat: recovery and failover

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -471,6 +471,9 @@ type ComponentGroupReplicasStatus struct {
 
 	// Running is the running replicas in the group.
 	Running int32 `json:"running"`
+
+	// Exists is the existence status of the group.
+	Exists bool `json:"found,omitempty"`
 }
 
 // ComponentReplicasStatus are the running status of Pods of the component.

--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -473,7 +473,7 @@ type ComponentGroupReplicasStatus struct {
 	Running int32 `json:"running"`
 
 	// Exists is the existence status of the group.
-	Exists bool `json:"found,omitempty"`
+	Exists bool `json:"exists,omitempty"`
 }
 
 // ComponentReplicasStatus are the running status of Pods of the component.

--- a/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
@@ -1260,6 +1260,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -1300,6 +1303,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -1340,6 +1346,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -1380,6 +1389,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string

--- a/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.singularity-data.com_risingwaves.yaml
@@ -1260,7 +1260,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -1303,7 +1303,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -1346,7 +1346,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -1389,7 +1389,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -8183,7 +8183,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8226,7 +8226,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8269,7 +8269,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8312,7 +8312,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -8183,6 +8183,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8223,6 +8226,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8263,6 +8269,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8303,6 +8312,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -8183,7 +8183,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8226,7 +8226,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8269,7 +8269,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:
@@ -8312,7 +8312,7 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
-                            found:
+                            exists:
                               description: Exists is the existence status of the group.
                               type: boolean
                             name:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -8183,6 +8183,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8223,6 +8226,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8263,6 +8269,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string
@@ -8303,6 +8312,9 @@ spec:
                           description: ComponentGroupReplicasStatus are the running
                             status of Pods in group.
                           properties:
+                            found:
+                              description: Exists is the existence status of the group.
+                              type: boolean
                             name:
                               description: Name is the name of the group.
                               type: string

--- a/pkg/controller/risingwave_controller.go
+++ b/pkg/controller/risingwave_controller.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -358,7 +357,9 @@ func (c *RisingWaveController) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&prometheusv1.ServiceMonitor{}).
+		// Can't watch an optional CRD. It will cause a panic in manager.
+		// So do not uncomment the following line.
+		// Owns(&prometheusv1.ServiceMonitor{}).
 		Complete(c)
 }
 

--- a/pkg/controller/risingwave_controller_test.go
+++ b/pkg/controller/risingwave_controller_test.go
@@ -108,6 +108,9 @@ func Test_RisingWaveController_New(t *testing.T) {
 				RisingWaveAction_MarkConditionInitializingAsTrue: newResultErr(ctrlkit.Continue()),
 				RisingWaveAction_MarkConditionRunningAsFalse:     newResultErr(ctrlkit.Continue()),
 
+				// Running(false) => stop
+				RisingWaveAction_BarrierConditionRunningIsFalse: newResultErr(ctrlkit.Exit()),
+
 				// Initializing(true) => stop
 				RisingWaveAction_BarrierConditionInitializingIsTrue: newResultErr(ctrlkit.Exit()),
 
@@ -122,7 +125,7 @@ func Test_RisingWaveController_New(t *testing.T) {
 
 				// Update status
 				RisingWaveAction_UpdateRisingWaveStatusViaClient: newResultErr(ctrlkit.Continue()),
-			}, true)
+			}, false)
 		},
 	}
 

--- a/pkg/ctrlkit/common.go
+++ b/pkg/ctrlkit/common.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Singularity Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctrlkit
+
+import ctrl "sigs.k8s.io/controller-runtime"
+
+type resultErr struct {
+	result ctrl.Result
+	err    error
+}

--- a/pkg/ctrlkit/shared.go
+++ b/pkg/ctrlkit/shared.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Singularity Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctrlkit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/singularity-data/risingwave-operator/pkg/ctrlkit/internal"
+)
+
+var _ internal.Decorator = &sharedAction{}
+
+type sharedAction struct {
+	inner Action
+
+	once   sync.Once
+	done   chan bool
+	result ctrl.Result
+	err    error
+}
+
+func (s *sharedAction) Inner() internal.Action {
+	return s.inner
+}
+
+func (s *sharedAction) SetInner(inner internal.Action) {
+	s.inner = inner
+}
+
+func (s *sharedAction) Name() string {
+	return "Shared"
+}
+
+func (s *sharedAction) Description() string {
+	return fmt.Sprintf("%s(%s)", s.Name(), s.inner.Description())
+}
+
+func (s *sharedAction) Run(ctx context.Context) (ctrl.Result, error) {
+	// Start a new goroutine to do this.
+	go s.once.Do(func() {
+		defer close(s.done)
+		s.result, s.err = s.inner.Run(ctx)
+		s.done <- true
+	})
+
+	// Wait on the done channel. Memory barrier should also be carried here.
+	<-s.done
+
+	return s.result, s.err
+}
+
+// Shared wraps the action into a shared action. Any executions against this action
+// would result in exactly once execution of the inner action and the same result.
+func Shared(inner Action) Action {
+	if _, ok := inner.(*sharedAction); ok {
+		return inner
+	}
+	return &sharedAction{
+		inner: inner,
+		done:  make(chan bool),
+	}
+}

--- a/pkg/ctrlkit/shared_test.go
+++ b/pkg/ctrlkit/shared_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 Singularity Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctrlkit
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Test_Shared_Decorator(t *testing.T) {
+	testDecorator[sharedAction](t, "Shared")
+}
+
+func newAtomicCounter(cnt *int32, resultErr resultErr) Action {
+	return NewAction("AtomicCounter", func(ctx context.Context) (ctrl.Result, error) {
+		atomic.AddInt32(cnt, 1)
+		return resultErr.result, resultErr.err
+	})
+}
+
+func Test_Shared_Optimize(t *testing.T) {
+	if Shared(Shared(Nop)).Description() != Shared(Nop).Description() {
+		t.Fail()
+	}
+}
+
+func Test_Shared(t *testing.T) {
+	testcases := map[string]struct {
+		resultErr resultErr
+		extraRun  int
+	}{
+		"extra-run-0": {
+			extraRun: 0,
+		},
+		"extra-run-1": {
+			extraRun: 1,
+		},
+		"extra-run-3": {
+			resultErr: resultErr{
+				result: ctrl.Result{RequeueAfter: time.Second},
+				err:    errors.New("some error"),
+			},
+			extraRun: 3,
+		},
+		"extra-run-10": {
+			resultErr: resultErr{
+				result: ctrl.Result{Requeue: true},
+				err:    nil,
+			},
+			extraRun: 10,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			cnt := int32(0)
+			shared := Shared(newAtomicCounter(&cnt, tc.resultErr))
+			var r ctrl.Result
+			var err error
+			firstRunDone := make(chan bool)
+			fatal := false
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				r, err = shared.Run(context.Background())
+				close(firstRunDone)
+			}()
+			for i := 0; i < tc.extraRun; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					extraR, extraErr := shared.Run(context.Background())
+
+					// Wait for the first result and compare.
+					<-firstRunDone
+					if r != extraR || err != extraErr {
+						fatal = true
+					}
+				}()
+			}
+			wg.Wait()
+
+			if fatal {
+				t.Fatal("result not the same")
+			}
+
+			if cnt != 1 {
+				t.Fatal("run count is not 1")
+			}
+		})
+	}
+}

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -739,7 +739,15 @@ func basicSetupContainer(container *corev1.Container, template *risingwavev1alph
 	})
 	container.Resources = template.Resources
 	container.StartupProbe = nil
-	container.LivenessProbe = nil
+	container.LivenessProbe = &corev1.Probe{
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       10,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromString(consts.PortService),
+			},
+		},
+	}
 	container.ReadinessProbe = &corev1.Probe{
 		InitialDelaySeconds: 10,
 		PeriodSeconds:       10,

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -782,6 +782,10 @@ func Test_RisingWaveObjectFactory_Deployments(t *testing.T) {
 							return equality.Semantic.DeepEqual(obj.Spec.Strategy, *tc.expectUpgradeStrategy)
 						}
 					}),
+					newObjectAssert(deploy, "first-container-must-have-probes", func(obj *appsv1.Deployment) bool {
+						container := &obj.Spec.Template.Spec.Containers[0]
+						return container.LivenessProbe != nil && container.ReadinessProbe != nil
+					}),
 				).Assert(t)
 			})
 		}
@@ -1054,6 +1058,10 @@ func Test_RisingWaveObjectFactory_StatefulSets(t *testing.T) {
 				}),
 				newObjectAssert(sts, "check-volume-mounts", func(obj *appsv1.StatefulSet) bool {
 					return listContainsByKey(obj.Spec.Template.Spec.Containers[0].VolumeMounts, tc.group.VolumeMounts, func(t *corev1.VolumeMount) string { return t.MountPath }, deepEqual[corev1.VolumeMount])
+				}),
+				newObjectAssert(sts, "first-container-must-have-probes", func(obj *appsv1.StatefulSet) bool {
+					container := &obj.Spec.Template.Spec.Containers[0]
+					return container.LivenessProbe != nil && container.ReadinessProbe != nil
 				}),
 			).Assert(t)
 		})

--- a/pkg/manager/risingwave_controller_manager.cm
+++ b/pkg/manager/risingwave_controller_manager.cm
@@ -120,9 +120,6 @@ decl RisingWaveControllerManager for RisingWave {
 
         // SyncConfigConfigMap creates or updates the configmap for RisingWave configs.
         SyncConfigConfigMap(configConfigMap)
-
-        // CollectRunningStatisticsAndSyncStatus collects running statistics and sync them into the status.
-        CollectRunningStatisticsAndSyncStatus(frontendService, metaService, computeService, compactorService, metaDeployments, frontendDeployments, computeStatefulSets, compactorDeployments, configConfigMap)
     }
 
     // ===================================================
@@ -141,5 +138,14 @@ decl RisingWaveControllerManager for RisingWave {
     action {
         // SyncServiceMonitor creates or updates the service monitor for RisingWave.
         SyncServiceMonitor(serviceMonitor)
+    }
+
+    // ===================================================
+    // The actions that needs all states.
+    // ===================================================
+
+    action {
+        // CollectRunningStatisticsAndSyncStatus collects running statistics and sync them into the status.
+        CollectRunningStatisticsAndSyncStatus(frontendService, metaService, computeService, compactorService, metaDeployments, frontendDeployments, computeStatefulSets, compactorDeployments, configConfigMap, serviceMonitor)
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Configure liveness probes on the component pods.
- Detect and recover the missing sub-resources.
  - Detect missing services or workloads results in a transition of condition `Running` from `True` to `False`
  - Try to recover all the components when `Running = False`
- Misc
  - Add a new action decorator `Shared` for sharing actions, i.e. run exactly once regardless of how many times it executes and returns the same result for each execution.
  - Add a new field `exists` in replicas status to indicate if the group exists now.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close #64 