### PR TITLE
feat: set the serviceName for the compute StatefulSet to make each co…

### DIFF
--- a/pkg/controller/risingwave_controller.go
+++ b/pkg/controller/risingwave_controller.go
@@ -245,7 +245,7 @@ func (c *RisingWaveController) reactiveWorkflow(risingwaveManger *object.RisingW
 		mgr.SyncServiceMonitor(),
 	)
 	syncOtherComponents := ctrlkit.ParallelJoin(
-		ctrlkit.ParallelJoin(
+		ctrlkit.Sequential(
 			mgr.SyncComputeService(),
 			mgr.SyncComputeStatefulSets(),
 		),

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -748,6 +748,16 @@ func basicSetupContainer(container *corev1.Container, template *risingwavev1alph
 	}, func(env *corev1.EnvVar) bool {
 		return env.Name == "POD_IP"
 	})
+	container.Env = mergeListByKey(container.Env, corev1.EnvVar{
+		Name: "POD_NAME",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.name",
+			},
+		},
+	}, func(env *corev1.EnvVar) bool {
+		return env.Name == "POD_NAME"
+	})
 	container.Resources = template.Resources
 	container.StartupProbe = nil
 	container.LivenessProbe = &corev1.Probe{
@@ -1089,6 +1099,7 @@ func (f *RisingWaveObjectFactory) NewComputeStatefulSet(group string, podTemplat
 		ObjectMeta: f.componentGroupObjectMeta(consts.ComponentCompute, group, true),
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:       pointer.Int32(componentGroup.Replicas),
+			ServiceName:    f.componentName(consts.ComponentCompute, ""),
 			UpdateStrategy: buildUpgradeStrategyForStatefulSet(componentGroup.UpgradeStrategy),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labelsOrSelectors,


### PR DESCRIPTION
…mpute Pod has a stable network identity

Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As mentioned in the title.

Now each pod of the compute component has a stable network identity throughout its lifetime (no matter whether scaled), i.e. each pod has a DNS record resolved to its IP.

```plain
k exec -it network-utils bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
bash-5.1# ping risingwave-in-memory-compute-0.risingwave-in-memory-compute
PING risingwave-in-memory-compute-0.risingwave-in-memory-compute.default.svc.cluster.local (10.1.2.238) 56(84) bytes of data.
64 bytes from risingwave-in-memory-compute-0.risingwave-in-memory-compute.default.svc.cluster.local (10.1.2.238): icmp_seq=1 ttl=64 time=0.323 ms
64 bytes from risingwave-in-memory-compute-0.risingwave-in-memory-compute.default.svc.cluster.local (10.1.2.238): icmp_seq=2 ttl=64 time=0.054 ms
```

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

related but not resolved #133 