### PR TITLE
fix: e2e-test failed should exit with code 1

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -153,4 +153,9 @@ for testcase in ${E2E_TESTCASES}; do
   background "run_e2e_test $testcase"
 done
 
-reap && echo "Excellent! All tests are passed!" || echo "Ooops! Some tests failed!"
+if [ $reap -eq 0 ]; then
+  echo "Excellent! All tests are passed!"
+else
+  echo "Ooops! Some tests failed!"
+  exit 1
+fi


### PR DESCRIPTION
## What's changed and what's your intention?

Currently, if e2e-test failed, github action will still treat it as a sucessuful task: [example](https://github.com/singularity-data/risingwave-operator/runs/7495525061?check_suite_focus=true).

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

