### PR TITLE
test(e2e): fix the test script

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -153,7 +153,7 @@ for testcase in ${E2E_TESTCASES}; do
   background "run_e2e_test $testcase"
 done
 
-if [ $reap -eq 0 ]; then
+if reap; then
   echo "Excellent! All tests are passed!"
 else
   echo "Ooops! Some tests failed!"


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Fix the test script.

```shell
if [ $reap -eq 0 ]
```
causes an error `[: -eq: unary operator expected`, I think it should be `[[ $reap -eq 0 ]]` in bash. But anyway, `if reap` always works.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
