### PR TITLE
feat: complete scale, stop and resume commands

### DIFF
--- a/pkg/command/create/config/config.go
+++ b/pkg/command/create/config/config.go
@@ -33,7 +33,7 @@ const (
 	DefaultRequestsCPU = "100Mi"
 )
 
-// Config contain the fields needed that creating a instance
+// Config contain the fields needed that creating a instance.
 type Config struct {
 	BaseConfig
 
@@ -114,7 +114,7 @@ var DefaultConfig = Config{
 	},
 }
 
-// ApplyConfigFile will construct a config by config file
+// ApplyConfigFile will construct a config by config file.
 func ApplyConfigFile(path string, arch string) (Config, error) {
 	if len(arch) != 0 {
 		DefaultConfig.Arch = arch

--- a/pkg/command/create/config/config_test.go
+++ b/pkg/command/create/config/config_test.go
@@ -17,8 +17,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApplyConfigFile(t *testing.T) {

--- a/pkg/command/create/create.go
+++ b/pkg/command/create/create.go
@@ -137,8 +137,9 @@ func (o *Options) createInstance() (*v1alpha1.RisingWave, error) {
 	c := o.config
 	rw := &v1alpha1.RisingWave{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: o.namespace,
-			Name:      o.name,
+			Namespace:   o.namespace,
+			Name:        o.name,
+			Annotations: make(map[string]string),
 		},
 		Spec: v1alpha1.RisingWaveSpec{
 			Global: v1alpha1.RisingWaveGlobalSpec{

--- a/pkg/command/create/create.go
+++ b/pkg/command/create/create.go
@@ -132,7 +132,7 @@ func (o *Options) Run(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []stri
 }
 
 // TODO: to support create different risingwave by config file
-// TODO: to support different storage by config file
+// TODO: to support different storage by config file.
 func (o *Options) createInstance() (*v1alpha1.RisingWave, error) {
 	c := o.config
 	rw := &v1alpha1.RisingWave{

--- a/pkg/command/create/create_test.go
+++ b/pkg/command/create/create_test.go
@@ -17,9 +17,11 @@
 package create
 
 import (
-	"github.com/singularity-data/risingwave-operator/pkg/command/create/config"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/singularity-data/risingwave-operator/pkg/command/create/config"
 )
 
 func Test_CreateInstance(t *testing.T) {

--- a/pkg/command/resume/resume.go
+++ b/pkg/command/resume/resume.go
@@ -117,9 +117,14 @@ func ResumeRisingWave(instance *v1alpha1.RisingWave) error {
 	// deserialize the annotation
 	// TODO: move this to utils
 	replicas := stop.GroupReplicas{}
+
+	if instance.Annotations == nil {
+		return fmt.Errorf("error replica information. are you trying to resume an instance that was not stopped?")
+	}
+
 	err := json.Unmarshal([]byte(instance.Annotations["replicas.old"]), &replicas)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal replicas, %v", err)
+		return fmt.Errorf("failed to unmarshal replicas, %v; are you trying to resume an instance that was not stopped?", err)
 	}
 
 	for _, replicaInfo := range replicas.Compute {

--- a/pkg/command/resume/resume.go
+++ b/pkg/command/resume/resume.go
@@ -1,0 +1,161 @@
+package resume
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/singularity-data/risingwave-operator/apis/risingwave/v1alpha1"
+	cmdcontext "github.com/singularity-data/risingwave-operator/pkg/command/context"
+	"github.com/singularity-data/risingwave-operator/pkg/command/stop"
+	"github.com/singularity-data/risingwave-operator/pkg/command/util"
+)
+
+const (
+	LongDesc = `
+Start the risingwave instances.
+`
+	Example = `  # Resume risingwave named example-rw in default namespace.
+  kubectl rw resume example-rw
+
+  # Stop risingwave named example-rw in foo namespace.
+  kubectl rw resume example-rw -n foo
+`
+)
+
+type Options struct {
+	name string
+
+	namespace string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns a stop Options.
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: streams,
+	}
+}
+
+// NewCommand creates the stop command.
+func NewCommand(ctx *cmdcontext.RWContext, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:     "Resume",
+		Short:   "Resume risingwave instances",
+		Long:    LongDesc,
+		Example: Example,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Complete(ctx, cmd, args))
+			util.CheckErr(o.Validate(ctx, cmd, args))
+			util.CheckErr(o.Run(ctx, cmd, args))
+		},
+		Aliases: []string{"stp"},
+	}
+
+	return cmd
+}
+
+func (o *Options) Complete(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+	if len(ctx.Namespace()) == 0 {
+		o.namespace = "default"
+	} else {
+		o.namespace = ctx.Namespace()
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("name of risingwave cannot be nil")
+	} else {
+		o.name = args[0]
+	}
+	return nil
+}
+
+func (o *Options) Validate(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+
+	return nil
+}
+
+func (o *Options) Run(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+	rw := &v1alpha1.RisingWave{}
+
+	operatorKey := client.ObjectKey{
+		Name:      o.name,
+		Namespace: o.namespace,
+	}
+
+	err := ctx.Client().Get(context.Background(), operatorKey, rw)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Fprint(o.Out, "Risingwave instance not exists")
+			return nil
+		}
+		return err
+	}
+
+	o.updateInstance(rw)
+
+	err = ctx.Client().Update(context.Background(), rw)
+	if err != nil {
+		return fmt.Errorf("failed to update instance, %w", err)
+	}
+
+	fmt.Fprint(o.Out, "Risingwave instance updated")
+	return nil
+}
+
+func (o *Options) updateInstance(instance *v1alpha1.RisingWave) {
+	// deserialize the annotation
+	replicas := stop.GroupReplicas{}
+	err := json.Unmarshal([]byte(instance.Annotations["replicas.old"]), &replicas)
+	if err != nil {
+		err := fmt.Sprintf("failed to unmarshal replicas, %v", err)
+		fmt.Fprint(o.Out, err)
+	}
+
+	for _, replicaInfo := range replicas.Compute {
+		for i, group := range instance.Spec.Components.Compute.Groups {
+			if group.Name == replicaInfo.GroupName {
+				instance.Spec.Components.Compute.Groups[i].Replicas = replicaInfo.Replicas
+				break
+			}
+		}
+	}
+
+	for _, replicaInfo := range replicas.Compactor {
+		for i, group := range instance.Spec.Components.Compactor.Groups {
+			if group.Name == replicaInfo.GroupName {
+				instance.Spec.Components.Compactor.Groups[i].Replicas = replicaInfo.Replicas
+				break
+			}
+		}
+	}
+
+	for _, replicaInfo := range replicas.Frontend {
+		for i, group := range instance.Spec.Components.Frontend.Groups {
+			if group.Name == replicaInfo.GroupName {
+				instance.Spec.Components.Frontend.Groups[i].Replicas = replicaInfo.Replicas
+				break
+			}
+		}
+	}
+
+	for _, replicaInfo := range replicas.Meta {
+		for i, group := range instance.Spec.Components.Meta.Groups {
+			if group.Name == replicaInfo.GroupName {
+				instance.Spec.Components.Meta.Groups[i].Replicas = replicaInfo.Replicas
+				break
+			}
+		}
+	}
+
+	// delete annotation
+	delete(instance.Annotations, "replicas.old")
+}

--- a/pkg/command/resume/resume.go
+++ b/pkg/command/resume/resume.go
@@ -119,7 +119,7 @@ func ResumeRisingWave(instance *v1alpha1.RisingWave) error {
 	replicas := stop.GroupReplicas{}
 
 	if instance.Annotations == nil {
-		return fmt.Errorf("error replica information. are you trying to resume an instance that was not stopped?")
+		return fmt.Errorf("error retrieving replica information; are you trying to resume an instance that was not stopped?")
 	}
 
 	err := json.Unmarshal([]byte(instance.Annotations["replicas.old"]), &replicas)

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/singularity-data/risingwave-operator/pkg/command/delete"
 	"github.com/singularity-data/risingwave-operator/pkg/command/install"
 	"github.com/singularity-data/risingwave-operator/pkg/command/list"
+	"github.com/singularity-data/risingwave-operator/pkg/command/restart"
 	"github.com/singularity-data/risingwave-operator/pkg/command/resume"
 	"github.com/singularity-data/risingwave-operator/pkg/command/scale"
 	"github.com/singularity-data/risingwave-operator/pkg/command/stop"
@@ -78,6 +79,7 @@ func NewCtlCommand(streams genericclioptions.IOStreams) *cobra.Command {
 				scale.NewCommand(ctx, streams),
 				stop.NewCommand(ctx, streams),
 				resume.NewCommand(ctx, streams),
+				restart.NewCommand(ctx, streams),
 			},
 		},
 	}

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -27,7 +27,9 @@ import (
 	"github.com/singularity-data/risingwave-operator/pkg/command/delete"
 	"github.com/singularity-data/risingwave-operator/pkg/command/install"
 	"github.com/singularity-data/risingwave-operator/pkg/command/list"
+	"github.com/singularity-data/risingwave-operator/pkg/command/resume"
 	"github.com/singularity-data/risingwave-operator/pkg/command/scale"
+	"github.com/singularity-data/risingwave-operator/pkg/command/stop"
 	"github.com/singularity-data/risingwave-operator/pkg/command/version"
 )
 
@@ -74,6 +76,8 @@ func NewCtlCommand(streams genericclioptions.IOStreams) *cobra.Command {
 			Message: "Deploy Commands:",
 			Commands: []*cobra.Command{
 				scale.NewCommand(ctx, streams),
+				stop.NewCommand(ctx, streams),
+				resume.NewCommand(ctx, streams),
 			},
 		},
 	}

--- a/pkg/command/stop/stop.go
+++ b/pkg/command/stop/stop.go
@@ -1,0 +1,175 @@
+package stop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/singularity-data/risingwave-operator/apis/risingwave/v1alpha1"
+	cmdcontext "github.com/singularity-data/risingwave-operator/pkg/command/context"
+	"github.com/singularity-data/risingwave-operator/pkg/command/scale"
+	"github.com/singularity-data/risingwave-operator/pkg/command/util"
+)
+
+const (
+	LongDesc = `
+Stop the risingwave instances.
+`
+	Example = `  # Stop risingwave named example-rw in default namespace.
+  kubectl rw stop example-rw
+
+  # Stop risingwave named example-rw in foo namespace.
+  kubectl rw stop example-rw -n foo
+`
+)
+
+type Options struct {
+	name string
+
+	namespace string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns a stop Options.
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: streams,
+	}
+}
+
+// NewCommand creates the stop command.
+func NewCommand(ctx *cmdcontext.RWContext, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:     "stop",
+		Short:   "Stop risingwave instances",
+		Long:    LongDesc,
+		Example: Example,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.Complete(ctx, cmd, args))
+			util.CheckErr(o.Validate(ctx, cmd, args))
+			util.CheckErr(o.Run(ctx, cmd, args))
+		},
+		Aliases: []string{"stp"},
+	}
+
+	return cmd
+}
+
+func (o *Options) Complete(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+	if len(ctx.Namespace()) == 0 {
+		o.namespace = "default"
+	} else {
+		o.namespace = ctx.Namespace()
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("name of risingwave cannot be nil")
+	} else {
+		o.name = args[0]
+	}
+	return nil
+}
+
+func (o *Options) Validate(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+
+	return nil
+}
+
+func (o *Options) Run(ctx *cmdcontext.RWContext, cmd *cobra.Command, args []string) error {
+	rw := &v1alpha1.RisingWave{}
+
+	operatorKey := client.ObjectKey{
+		Name:      o.name,
+		Namespace: o.namespace,
+	}
+
+	err := ctx.Client().Get(context.Background(), operatorKey, rw)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Fprint(o.Out, "Risingwave instance not exists")
+			return nil
+		}
+		return err
+	}
+
+	o.updateInstance(rw)
+
+	err = ctx.Client().Update(context.Background(), rw)
+	if err != nil {
+		return fmt.Errorf("failed to update instance, %w", err)
+	}
+
+	fmt.Fprint(o.Out, "Risingwave instance updated")
+	return nil
+}
+
+type GroupReplicas struct {
+	Compute   []ReplicaInfo
+	Frontend  []ReplicaInfo
+	Compactor []ReplicaInfo
+	Meta      []ReplicaInfo
+}
+
+type ReplicaInfo struct {
+	GroupName string
+	Replicas  int32
+}
+
+func (o *Options) updateInstance(instance *v1alpha1.RisingWave) {
+	replicas := GroupReplicas{}
+
+	// record current replica values in annotation
+	for _, group := range instance.Spec.Components.Compute.Groups {
+		computeReplica := ReplicaInfo{
+			GroupName: group.Name,
+			Replicas:  group.Replicas,
+		}
+		// TODO: use constants for component naming
+		scale.UpdateReplicas(instance, "compute", group.Name, 0)
+		replicas.Compute = append(replicas.Compute, computeReplica)
+	}
+
+	for _, group := range instance.Spec.Components.Frontend.Groups {
+		frontendReplica := ReplicaInfo{
+			GroupName: group.Name,
+			Replicas:  group.Replicas,
+		}
+		scale.UpdateReplicas(instance, "frontend", group.Name, 0)
+		replicas.Frontend = append(replicas.Frontend, frontendReplica)
+	}
+
+	for _, group := range instance.Spec.Components.Compactor.Groups {
+		compactorReplica := ReplicaInfo{
+			GroupName: group.Name,
+			Replicas:  group.Replicas,
+		}
+		scale.UpdateReplicas(instance, "compactor", group.Name, 0)
+		replicas.Compactor = append(replicas.Compactor, compactorReplica)
+	}
+
+	for _, group := range instance.Spec.Components.Meta.Groups {
+		metaReplica := ReplicaInfo{
+			GroupName: group.Name,
+			Replicas:  group.Replicas,
+		}
+		scale.UpdateReplicas(instance, "meta", group.Name, 0)
+		replicas.Meta = append(replicas.Meta, metaReplica)
+	}
+
+	// serialise replica struct to annotation
+	annotation, err := json.Marshal(replicas)
+	if err != nil {
+		fmt.Fprint(o.Out, "Failed to serialise replicas", err)
+	}
+
+	// set annotation
+	instance.Annotations["replicas.old"] = string(annotation)
+}


### PR DESCRIPTION
## What's changed and what's your intention?
- Completed scale, stop and resume commands
- Stop and resume commands use annotations to store and restore replica numbers 
- Create POC for restart command

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
