### PR TITLE
feat: set RW_WORKER_THREADS accroding to the resource limits

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -746,9 +746,7 @@ func basicSetupContainer(container *corev1.Container, template *risingwavev1alph
 				FieldPath: "status.podIP",
 			},
 		},
-	}, func(env *corev1.EnvVar) bool {
-		return env.Name == "POD_IP"
-	})
+	}, func(env *corev1.EnvVar) bool { return env.Name == "POD_IP" })
 	container.Env = mergeListByKey(container.Env, corev1.EnvVar{
 		Name: "POD_NAME",
 		ValueFrom: &corev1.EnvVarSource{
@@ -756,9 +754,13 @@ func basicSetupContainer(container *corev1.Container, template *risingwavev1alph
 				FieldPath: "metadata.name",
 			},
 		},
-	}, func(env *corev1.EnvVar) bool {
-		return env.Name == "POD_NAME"
-	})
+	}, func(env *corev1.EnvVar) bool { return env.Name == "POD_NAME" })
+	if cpuLimit, ok := template.Resources.Limits[corev1.ResourceCPU]; ok {
+		container.Env = mergeListByKey(container.Env, corev1.EnvVar{
+			Name:  "RW_WORKER_THREADS",
+			Value: strconv.FormatInt(cpuLimit.Value(), 10),
+		}, func(env *corev1.EnvVar) bool { return env.Name == "RW_WORKER_THREADS" })
+	}
 	container.Resources = template.Resources
 	container.StartupProbe = nil
 	container.LivenessProbe = &corev1.Probe{


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- According to the kernel [code](https://github.com/singularity-data/risingwave/blob/613ed1a7a6faeefb8c6167b92989cb7bf46faa69/src/utils/runtime/src/lib.rs#L269-L292), there's an env variable `RW_WORKER_THREADS` that helps control the worker threads size. This PR supports setting the worker threads pool size with it if and only if there's a CPU limit on resources. The value is rounded up to the nearest integer away from 0, e.g. 100m results in 1, and 1.6 results in 2.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
