### PR TITLE
fix: make sure the pod spec is stable by sorting the slices

### DIFF
--- a/pkg/ctrlkit/join.go
+++ b/pkg/ctrlkit/join.go
@@ -28,10 +28,10 @@ import (
 )
 
 // Join the errors with the following rules:
-//   * any + nil = any
-//   * exit + exit = exit
-//   * err + exit = err
-//   * err1 + err2 = [err1, err2]
+//   - any + nil = any
+//   - exit + exit = exit
+//   - err + exit = err
+//   - err1 + err2 = [err1, err2]
 func joinErr(err1, err2 error) error {
 	if err1 == nil {
 		return err2
@@ -54,9 +54,9 @@ func joinErr(err1, err2 error) error {
 }
 
 // joinResultAndErr joins results by the following rules:
-//   * Join the errors with joinErr
-//   * If it requires requeue, set the requeue in the global one
-//   * If it sets a requeue after, set the requeue after if the global one
+//   - Join the errors with joinErr
+//   - If it requires requeue, set the requeue in the global one
+//   - If it sets a requeue after, set the requeue after if the global one
 //     if there's none or it's longer than the local one
 func joinResultAndErr(result ctrl.Result, err error, lresult ctrl.Result, lerr error) (ctrl.Result, error) {
 	if lresult.Requeue {

--- a/pkg/ctrlkit/optimize.go
+++ b/pkg/ctrlkit/optimize.go
@@ -90,14 +90,14 @@ func optimizeJoin(workflow *joinGroup) Action {
 }
 
 // OptimizeWorkflow optimizes the workflow by eliminating unnecessary layers:
-//   * Nop in Sequential or Join will be removed
-//   * Empty Join and Sequential will be omitted
-//   * Parallel in Sequential will be unwrapped
-//   * Sequential and Join with single child will be simplified by removing them
-//   * Sequential(Sequential) will be flattened
-//   * Join(Join) will be flattened
-//   * Parallel(Parallel) will be simplified with only one Parallel
-//   * Timeout(Timeout) will be simplified with the tighter timeout
+//   - Nop in Sequential or Join will be removed
+//   - Empty Join and Sequential will be omitted
+//   - Parallel in Sequential will be unwrapped
+//   - Sequential and Join with single child will be simplified by removing them
+//   - Sequential(Sequential) will be flattened
+//   - Join(Join) will be flattened
+//   - Parallel(Parallel) will be simplified with only one Parallel
+//   - Timeout(Timeout) will be simplified with the tighter timeout
 func OptimizeWorkflow(workflow Action) Action {
 	switch workflow := workflow.(type) {
 	case *sequentialGroup:

--- a/pkg/factory/common.go
+++ b/pkg/factory/common.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Singularity Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package factory
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/singularity-data/risingwave-operator/pkg/utils"
+)
+
+func nonZeroOrDefault[T comparable](v T, defaultVal T) T {
+	var zero T
+	if v == zero {
+		return defaultVal
+	}
+	return v
+}
+
+func sortSlicesInContainer(container *corev1.Container) {
+	sort.Sort(utils.EnvVarSlice(container.Env))
+	sort.Sort(utils.VolumeMountSlice(container.VolumeMounts))
+	sort.Sort(utils.VolumeDeviceSlice(container.VolumeDevices))
+}
+
+func keepPodSpecConsistent(podSpec *corev1.PodSpec) {
+	// Sort slices to make sure there's no random order. Currently, these fields are considered:
+	//   - Volumes (sorted by name)
+	//   - For each container
+	//     - Env (sorted by name)
+	//     - VolumeMounts (sorted by name)
+	//     - VolumeDevices (sorted by name)
+
+	sort.Sort(utils.VolumeSlice(podSpec.Volumes))
+
+	for _, container := range podSpec.InitContainers {
+		sortSlicesInContainer(&container)
+	}
+
+	for _, container := range podSpec.Containers {
+		sortSlicesInContainer(&container)
+	}
+}

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -36,14 +36,6 @@ import (
 	"github.com/singularity-data/risingwave-operator/pkg/consts"
 )
 
-func nonZeroOrDefault[T comparable](v T, defaultVal T) T {
-	var zero T
-	if v == zero {
-		return defaultVal
-	}
-	return v
-}
-
 const (
 	risingWaveConfigVolume   = "risingwave-config"
 	risingWaveConfigMapKey   = "risingwave.toml"
@@ -650,7 +642,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplate(component, group string, podT
 		podTemplate.Annotations[consts.AnnotationRestartAt] = restartAt.In(time.UTC).Format("2006-01-02T15:04:05Z")
 	}
 
-	// Setup the first container.
+	// Set up the first container.
 	if len(podTemplate.Spec.Containers) == 0 {
 		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, corev1.Container{})
 	}
@@ -847,8 +839,11 @@ func (f *RisingWaveObjectFactory) NewMetaDeployment(group string, podTemplates m
 	// Build the pod template.
 	podTemplate := f.buildPodTemplate(consts.ComponentMeta, group, podTemplates, componentGroup.RisingWaveComponentGroupTemplate, restartAt)
 
-	// Setup the first container.
+	// Set up the first container.
 	f.setupMetaContainer(&podTemplate.Spec.Containers[0], componentGroup.RisingWaveComponentGroupTemplate)
+
+	// Make sure it's stable among builds.
+	keepPodSpecConsistent(&podTemplate.Spec)
 
 	// Build the deployment.
 	labelsOrSelectors := f.podLabelsOrSelectorsForGroup(consts.ComponentMeta, group)
@@ -914,8 +909,11 @@ func (f *RisingWaveObjectFactory) NewFrontendDeployment(group string, podTemplat
 	// Build the pod template.
 	podTemplate := f.buildPodTemplate(consts.ComponentFrontend, group, podTemplates, componentGroup.RisingWaveComponentGroupTemplate, restartAt)
 
-	// Setup the first container.
+	// Set up the first container.
 	f.setupFrontendContainer(&podTemplate.Spec.Containers[0], componentGroup.RisingWaveComponentGroupTemplate)
+
+	// Make sure it's stable among builds.
+	keepPodSpecConsistent(&podTemplate.Spec)
 
 	// Build the deployment.
 	labelsOrSelectors := f.podLabelsOrSelectorsForGroup(consts.ComponentFrontend, group)
@@ -993,8 +991,11 @@ func (f *RisingWaveObjectFactory) NewCompactorDeployment(group string, podTempla
 	// Build the pod template.
 	podTemplate := f.buildPodTemplate(consts.ComponentCompactor, group, podTemplates, componentGroup.RisingWaveComponentGroupTemplate, restartAt)
 
-	// Setup the first container.
+	// Set up the first container.
 	f.setupCompactorContainer(&podTemplate.Spec.Containers[0], componentGroup.RisingWaveComponentGroupTemplate)
+
+	// Make sure it's stable among builds.
+	keepPodSpecConsistent(&podTemplate.Spec)
 
 	// Build the deployment.
 	labelsOrSelectors := f.podLabelsOrSelectorsForGroup(consts.ComponentCompactor, group)
@@ -1093,8 +1094,11 @@ func (f *RisingWaveObjectFactory) NewComputeStatefulSet(group string, podTemplat
 	// Build the pod template.
 	podTemplate := f.buildPodTemplate(consts.ComponentCompute, group, podTemplates, &componentGroup.RisingWaveComponentGroupTemplate, restartAt)
 
-	// Setup the first container.
+	// Set up the first container.
 	f.setupComputeContainer(&podTemplate.Spec.Containers[0], componentGroup.RisingWaveComputeGroupTemplate)
+
+	// Make sure it's stable among builds.
+	keepPodSpecConsistent(&podTemplate.Spec)
 
 	// Build the statefulset.
 	labelsOrSelectors := f.podLabelsOrSelectorsForGroup(consts.ComponentCompute, group)

--- a/pkg/manager/risingwave_controller_manager_generated.go
+++ b/pkg/manager/risingwave_controller_manager_generated.go
@@ -46,9 +46,9 @@ type RisingWaveControllerManagerState struct {
 }
 
 // GetCompactorDeployments lists compactorDeployments with the following selectors:
-//   + labels/risingwave/component=compactor
-//   + labels/risingwave/name=${target.Name}
-//   + owned
+//   - labels/risingwave/component=compactor
+//   - labels/risingwave/name=${target.Name}
+//   - owned
 func (s *RisingWaveControllerManagerState) GetCompactorDeployments(ctx context.Context) ([]appsv1.Deployment, error) {
 	var compactorDeploymentsList appsv1.DeploymentList
 
@@ -116,9 +116,9 @@ func (s *RisingWaveControllerManagerState) GetComputeService(ctx context.Context
 }
 
 // GetComputeStatefulSets lists computeStatefulSets with the following selectors:
-//   + labels/risingwave/component=compute
-//   + labels/risingwave/name=${target.Name}
-//   + owned
+//   - labels/risingwave/component=compute
+//   - labels/risingwave/name=${target.Name}
+//   - owned
 func (s *RisingWaveControllerManagerState) GetComputeStatefulSets(ctx context.Context) ([]appsv1.StatefulSet, error) {
 	var computeStatefulSetsList appsv1.StatefulSetList
 
@@ -165,9 +165,9 @@ func (s *RisingWaveControllerManagerState) GetConfigConfigMap(ctx context.Contex
 }
 
 // GetFrontendDeployments lists frontendDeployments with the following selectors:
-//   + labels/risingwave/component=frontend
-//   + labels/risingwave/name=${target.Name}
-//   + owned
+//   - labels/risingwave/component=frontend
+//   - labels/risingwave/name=${target.Name}
+//   - owned
 func (s *RisingWaveControllerManagerState) GetFrontendDeployments(ctx context.Context) ([]appsv1.Deployment, error) {
 	var frontendDeploymentsList appsv1.DeploymentList
 
@@ -214,9 +214,9 @@ func (s *RisingWaveControllerManagerState) GetFrontendService(ctx context.Contex
 }
 
 // GetMetaDeployments lists metaDeployments with the following selectors:
-//   + labels/risingwave/component=meta
-//   + labels/risingwave/name=${target.Name}
-//   + owned
+//   - labels/risingwave/component=meta
+//   - labels/risingwave/name=${target.Name}
+//   - owned
 func (s *RisingWaveControllerManagerState) GetMetaDeployments(ctx context.Context) ([]appsv1.Deployment, error) {
 	var metaDeploymentsList appsv1.DeploymentList
 

--- a/pkg/utils/sort.go
+++ b/pkg/utils/sort.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Singularity Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import corev1 "k8s.io/api/core/v1"
+
+func swap[T any](a, b *T) {
+	t := *a
+	*a = *b
+	*b = t
+}
+
+type EnvVarSlice []corev1.EnvVar
+
+func (s EnvVarSlice) Len() int {
+	return len(s)
+}
+
+func (s EnvVarSlice) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func (s EnvVarSlice) Swap(i, j int) {
+	swap(&s[i], &s[j])
+}
+
+type VolumeMountSlice []corev1.VolumeMount
+
+func (s VolumeMountSlice) Len() int {
+	return len(s)
+}
+
+func (s VolumeMountSlice) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func (s VolumeMountSlice) Swap(i, j int) {
+	swap(&s[i], &s[j])
+}
+
+type VolumeSlice []corev1.Volume
+
+func (s VolumeSlice) Len() int {
+	return len(s)
+}
+
+func (s VolumeSlice) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func (s VolumeSlice) Swap(i, j int) {
+	swap(&s[i], &s[j])
+}
+
+type VolumeDeviceSlice []corev1.VolumeDevice
+
+func (s VolumeDeviceSlice) Len() int {
+	return len(s)
+}
+
+func (s VolumeDeviceSlice) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func (s VolumeDeviceSlice) Swap(i, j int) {
+	swap(&s[i], &s[j])
+}


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Fix the possible issue that would be caused by unstable lists in pod spec in the future, e.g., if there's an unstable `Volumes` list in the `Deployment` of frontend, syncing of replicas change might trigger a full rebuild of the Pods because of that.
- Comment formats introduced by go 1.19

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
